### PR TITLE
Fixed bug that made superagent crash after 60s because the request was not aborted

### DIFF
--- a/superagentCache.js
+++ b/superagentCache.js
@@ -7,7 +7,7 @@
 module.exports = function(agent, cache){
 
   var superagent = (agent) ? agent : require('superagent');
-  
+
   if(cache){
     superagent.cache = cache;
   }
@@ -121,6 +121,7 @@ module.exports = function(agent, cache){
         if(~cacheableMethods.indexOf(this.method)){
           superagent.cache.get(key, function (err, response){
             if(!err && response){
+              _this.abort();
               callbackExecutor(cb, err, response, key);
             }
             else{


### PR DESCRIPTION
Superagent will crash when you have cached requests that contain header. It seems that that is because node emits an error after 60 seconds if you have set headers but not sent the request (https://github.com/visionmedia/superagent/blob/master/lib/node/index.js#L732:L734).

To reproduce:

    var superagent = require('superagent');
    require('superagent-cache')(superagent);

    superagent
      .get('http://google.com')
      .set('test',1)
      .end(function(err, res) {
        console.log('done 1');
        superagent
          .get('http://google.com')
          .set('test',1)
          .end(function(err, res) {
            console.log('done 2');
          });
      });

    setTimeout(function(){
      console.log('still here?');
    }, 61*1000)

This will crash after 60s for me (node v5.0.0) because of the error callback

This PR should fix the issue, since the request will be aborted and therefore not throw an error when cached.