### PR TITLE
Make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,37 @@ You get the 'default configuration' when you don't provide any params to the `re
 
 # How Do I Use a Custom Configuration?
 
-To use a custom configuraiton, take advantage of the the two optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) as follows:
+To use a custom configuraiton, take advantage of the the three optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) as follows:
 
 ```javascript
 //Require superagent and the cache module I want
 var superagent = require('superagent');
 var redisModule = require('cache-service-redis');
 var redisCache = new redisModule({redisEnv: 'REDISCLOUD_URL'});
+var defaults = {cacheWhenEmpty: false, expiration: 900};
 
 //Patch my superagent instance and pass in my redis cache
-require('superagent-cache')(superagent, redisCache);
+require('superagent-cache')(superagent, redisCache, defaults);
 ```
 
-This example allows you to provide your own instance of `superagent` to be patched as well as allowing you to pass in your own, pre-instantiated cache. Here's a list of [supported caches](#supported-caches).
+This example allows you to provide your own instance of `superagent` to be patched as well as allowing you to pass in your own, pre-instantiated cache and some defaults for superagent-cache to use with all queries. Here's a list of [supported caches](#supported-caches).
 
-For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagentcache).
+All data passed in the `defaults` object will apply to all queryies made with superagent-cache unless overwritten with chainables. See the [Available Configuration Options](#available-configuration-options) section for a list of all options you can pass.
+
+For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagentcache) (this section does not speak at all about the `defaults` param).
+
+# Available Configuration Options
+
+All options that can be passed to the `defaults` `require` param can be overwritten with chainables of the same name. All of the below options are detailed in the [API section](#api).
+
+* responseProp
+* prune
+* pruneParams
+* pruneOptions
+* expiration
+* cacheWhenEmpty
+* doQuery
+* backgroundRefresh
 
 # Supported Caches
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This example allows you to provide your own instance of `superagent` to be patch
 
 All data passed in the `defaults` object will apply to all queryies made with superagent-cache unless overwritten with chainables. See the [Available Configuration Options](#available-configuration-options) section for a list of all options you can pass.
 
-For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagentcache) (this section does not speak at all about the `defaults` param).
+For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagentcache).
 
 # Available Configuration Options
 
@@ -415,6 +415,10 @@ var redisModule = require('cache-service-redis');
 var redisCache = new redisModule({redisEnv: 'REDISCLOUD_URL'});
 var superagent = require('superagent-cache')(null, redisCache);
 ```
+
+#### With `defaults`
+
+The `defaults` object can be passed as the third param at any time. It does not affect the `superagent` or `cache` params. You can see a brief demo [here](#how-do-i-use-a-custom-configuration) and a list of all the options you can pass in the `defaults` object [here](#available-configuration-options).
 
 # Breaking Change History
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ require('superagent-cache')(superagent, redisCache, defaults);
 
 This example allows you to provide your own instance of `superagent` to be patched as well as allowing you to pass in your own, pre-instantiated cache and some defaults for superagent-cache to use with all queries. Here's a list of [supported caches](#supported-caches).
 
-All data passed in the `defaults` object will apply to all queryies made with superagent-cache unless overwritten with chainables. See the [Available Configuration Options](#available-configuration-options) section for a list of all options you can pass.
+All data passed in the `defaults` object will apply to all queries made with superagent-cache unless overwritten with chainables. See the [Available Configuration Options](#available-configuration-options) section for a list of all options you can pass.
 
 For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagent-cache).
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You get the 'default configuration' when you don't provide any params to the `re
 
 # How Do I Use a Custom Configuration?
 
-To use a custom configuraiton, take advantage of the the three optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) as follows:
+To use a custom configuraiton, take advantage of the the three optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) (`superagent`, `cache`, and `defaults`) as follows:
 
 ```javascript
 //Require superagent and the cache module I want

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ superagent
 );
 ```
 
-## .prune(callback (response))
+## .prune(callback (response, gutFunction))
 
-> Caution: if you use this function, `supergent-cache` [will not gut](#what-exactly-gets-cached) the `response` object for you. Be sure that the result of your `.prune()` callback function will never be circular and is not larger than it needs to be.
+> Caution: if you use this function, `supergent-cache` [will not gut](#what-exactly-gets-cached) the `response` object for you. Be sure that the result of your `.prune()` callback function will never be circular and is not larger than it needs to be. If you are simply checking for the existence of an attribute and still want superagent-cache to gut the response for you, use the `gutFunction` param as shown in example 2 below.
 
 If you need to dig several layers into superagent's response, you can do so by passing a function to `.prune()`. Your prune function will receive superagent's response and should return a truthy value or null. The benefit of using this function is that you can cache only what you need.
 
@@ -183,12 +183,32 @@ If you need to dig several layers into superagent's response, you can do so by p
 #### Example
 
 ```javascript
-var prune = funtion(r){
-  return (r && r.ok && r.body && r.body.user) ? r.body.user : null;
+var prune = function(r, gut){
+  if(r && r.ok && r.body && r.body.user) ? r.body.user : null;
 }
 
 //response will now be replaced with r.body.urer or null
 //and only r.body.user will be cached rather than the entire superagent response
+superagent
+  .get(uri)
+  .prune(prune)
+  .end(function (error, response){
+    // handle response
+  }
+);
+```
+
+#### Example 2
+
+```javascript
+var prune = funtion(r, gut){
+  if(r && r.ok && r.body && r.body.user){
+    return gut(r);
+  }
+  return null;
+}
+
+//response will now be gutted by superagent-cache
 superagent
   .get(uri)
   .prune(prune)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This example allows you to provide your own instance of `superagent` to be patch
 
 All data passed in the `defaults` object will apply to all queryies made with superagent-cache unless overwritten with chainables. See the [Available Configuration Options](#available-configuration-options) section for a list of all options you can pass.
 
-For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagentcache).
+For more information on `require` command params usage, see [this section](#various-ways-of-requiring-superagent-cache).
 
 # Available Configuration Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-cache",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Superagent with flexible built-in caching.",
   "main": "superagentCache.js",
   "dependencies": {

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -126,7 +126,7 @@ module.exports = function(agent, cache, defaults){
                   }
                   else if(!err && response){
                     if(curProps.prune){
-                      response = curProps.prune(response);
+                      response = curProps.prune(response, gutResponse);
                     }
                     else if(curProps.responseProp){
                       response = response[curProps.responseProp] || null;

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -358,8 +358,11 @@ module.exports = function(agent, cache, defaults){
       if(cb.length === 1){
         cb(response);
       }
-      else{
+      else if(cb.length > 1){
         cb(err, response, key);
+      }
+      else{
+        throw new Error('UnsupportedCallbackException: Your .end() callback must pass at least one argument.');
       }
     }
   }

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -358,26 +358,9 @@ module.exports = function(agent, cache, defaults){
       if(cb.length === 1){
         cb(response);
       }
-      else if(cb.length === 2){
-        cb(err, response);
-      }
-      else if(cb.length === 3){
+      else{
         cb(err, response, key);
       }
-      else{
-        throw new exception('UnsupportedCallbackException', 'You must have 1, 2, or 3 callback params in your .end() callback argument list.');
-      }
-    }
-
-    /**
-     * Instantates an exception to be thrown
-     * @param {string} name
-     * @param {string} message
-     * @return {exception}
-     */
-    function exception(name, message){
-      this.name = name;
-      this.message = message;
     }
   }
 

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -126,7 +126,7 @@ module.exports = function(agent, cache, defaults){
                   }
                   else if(!err && response){
                     if(curProps.prune){
-                      response = curProps.prune(response, gutResponse);
+                      response = curProps.prune(response);
                     }
                     else if(curProps.responseProp){
                       response = response[curProps.responseProp] || null;

--- a/test/server/superagent-cache.js
+++ b/test/server/superagent-cache.js
@@ -43,13 +43,13 @@ app.get('/options', function(req, res){
 
 app.listen(3000);
 
-describe('superagentCache tests', function(){
+describe('superagentCache', function(){
 
   beforeEach(function(){
     superagent.cache.flush();
   });
 
-  describe('superagentCache API tests', function () {
+  describe('API tests', function () {
 
     it('.end() should not require the \'err\' callback param', function (done) {
       superagent
@@ -257,7 +257,7 @@ describe('superagentCache tests', function(){
 
   });
 
-  describe('superagentCache caching tests', function () {
+  describe('caching tests', function () {
 
     it('.get() ._end() should bypass all caching logic', function (done) {
       superagent
@@ -342,7 +342,7 @@ describe('superagentCache tests', function(){
 
   });
 
-  describe('superagentCache background refresh tests', function () {
+  describe('background refresh tests', function () {
 
     it('.get() .expiration() .end() background refresh should not work if the chainable is not used', function (done) {
       superagent
@@ -469,7 +469,7 @@ describe('superagentCache tests', function(){
 
   });
 
-  describe('superagentCache configurability tests', function () {
+  describe('configurability tests', function () {
     //Necessary to eliminate the superagent singleton so we can create another with a defaults object
     delete require.cache[require.resolve('superagent')];
     var superagent = require('superagent');

--- a/test/server/superagent-cache.js
+++ b/test/server/superagent-cache.js
@@ -473,9 +473,9 @@ describe('superagentCache', function(){
     //Necessary to eliminate the superagent singleton so we can create another with a defaults object
     delete require.cache[require.resolve('superagent')];
     var superagent = require('superagent');
-    require('../../superagentCache')(superagent, cacheModule, {doQuery: false});
+    require('../../superagentCache')(superagent, cacheModule, {doQuery: false, expiration: 1});
 
-    it('Should be able to configure some global settings', function (done) {
+    it('Should be able to configure some global settings: doQuery', function (done) {
       superagent
         .get('localhost:3000/one')
         .end(function (err, response, key){
@@ -487,7 +487,7 @@ describe('superagentCache', function(){
       );
     });
 
-    it('Global settings should be locally overwritten by chainables', function (done) {
+    it('Global settings should be locally overwritten by chainables: doQuery', function (done) {
       superagent
         .get('localhost:3000/one')
         .doQuery(true)
@@ -496,6 +496,56 @@ describe('superagentCache', function(){
             expect(response).toNotBe(null);
             expect(response.body.key).toBe('one');
             done();
+          });
+        }
+      );
+    });
+
+    it('Should be able to configure some global settings: expiration', function (done) {
+      superagent
+        .get('localhost:3000/one')
+        .doQuery(true)
+        .end(function (err, response, key){
+          superagent.cache.get(key, function (err, response) {
+            expect(response).toNotBe(null);
+            expect(response.body.key).toBe('one');
+            setTimeout(function(){
+              superagent
+                .get('localhost:3000/one')
+                .end(function (err, response, key){
+                  superagent.cache.get(key, function (err, response) {
+                    expect(response).toBe(null);
+                    done();
+                  });
+                }
+              );
+            }, 1000);
+          });
+        }
+      );
+    });
+
+    it('Global settings should be locally overwritten by chainables: expiration', function (done) {
+      superagent
+        .get('localhost:3000/one')
+        .doQuery(true)
+        .expiration(2)
+        .end(function (err, response, key){
+          superagent.cache.get(key, function (err, response) {
+            expect(response).toNotBe(null);
+            expect(response.body.key).toBe('one');
+            setTimeout(function(){
+              superagent
+                .get('localhost:3000/one')
+                .end(function (err, response, key){
+                  superagent.cache.get(key, function (err, response) {
+                    expect(response).toNotBe(null);
+                    expect(response.body.key).toBe('one');
+                    done();
+                  });
+                }
+              );
+            }, 1000);
           });
         }
       );

--- a/test/server/superagent-cache.js
+++ b/test/server/superagent-cache.js
@@ -473,13 +473,7 @@ describe('superagentCache', function(){
     //Necessary to eliminate the superagent singleton so we can create another with a defaults object
     delete require.cache[require.resolve('superagent')];
     var superagent = require('superagent');
-    var prune = function(r, gut){
-      if(r && r.statusCode && r.statusCode.toString()[0] === '2'){
-        return gut(r);
-      }
-      return null;
-    }
-    require('../../superagentCache')(superagent, cacheModule, {doQuery: false, expiration: 1, prune: prune});
+    require('../../superagentCache')(superagent, cacheModule, {doQuery: false, expiration: 1});
 
     it('Should be able to configure global settings: doQuery', function (done) {
       superagent
@@ -552,19 +546,6 @@ describe('superagentCache', function(){
                 }
               );
             }, 1000);
-          });
-        }
-      );
-    });
-
-    it('Global settings should be locally overwritten by chainables: prune', function (done) {
-      superagent
-        .get('localhost:3000/four')
-        .doQuery(true)
-        .end(function (err, response, key){
-          superagent.cache.get(key, function (err, response) {
-            expect(response).toBe(null);
-            done();
           });
         }
       );

--- a/test/server/superagent-cache.js
+++ b/test/server/superagent-cache.js
@@ -470,17 +470,16 @@ describe('superagentCache tests', function(){
   });
 
   describe('superagentCache configurability tests', function () {
+    //Necessary to eliminate the superagent singleton so we can create another with a defaults object
+    delete require.cache[require.resolve('superagent')];
+    var superagent = require('superagent');
+    require('../../superagentCache')(superagent, cacheModule, {doQuery: false});
 
     it('Should be able to configure some global settings', function (done) {
-      //delete superagent;
-      delete require.cache[superagentModuleName];
-      var superagent = require('superagent');
-      require('../../superagentCache')(superagent, cacheModule, {doQuery: false});
       superagent
         .get('localhost:3000/one')
         .end(function (err, response, key){
           superagent.cache.get(key, function (err, response) {
-            //console.log('RESPONSE', response);
             expect(response).toBe(null);
             done();
           });
@@ -489,16 +488,11 @@ describe('superagentCache tests', function(){
     });
 
     it('Global settings should be locally overwritten by chainables', function (done) {
-      //delete superagent;
-      delete require.cache[superagentModuleName];
-      var superagent = require('superagent');
-      require('../../superagentCache')(superagent, cacheModule, {doQuery: false});
       superagent
         .get('localhost:3000/one')
         .doQuery(true)
         .end(function (err, response, key){
           superagent.cache.get(key, function (err, response) {
-            //console.log('RESPONSE', response);
             expect(response).toNotBe(null);
             expect(response.body.key).toBe('one');
             done();


### PR DESCRIPTION
Adding the ability to pass a global configuration when instantiating superagent-cache. This will allow users to pass a config once instead of using a chainable in every query.