### PR TITLE
Making defaults public

### DIFF
--- a/superagentCache.js
+++ b/superagentCache.js
@@ -10,13 +10,13 @@ module.exports = function(agent, cache, defaults){
 
   if(superagent.patchedBySuperagentCache){
     superagent.cache = (cache) ? cache : superagent.cache;
-    defaults = (defaults) ? resetProps(defaults) : null;
+    superagent.defaults = (defaults) ? resetProps(defaults) : superagent.defaults;
   }
   else if(!superagent.patchedBySuperagentCache){
     superagent.cache = (cache) ? cache : new require('cache-service-cache-module')();
-    defaults = defaults || {};
+    superagent.defaults = defaults || {};
     var Request = superagent.Request;
-    var props = resetProps();
+    var props = resetProps(superagent.defaults);
     var supportedMethods = ['GET', 'HEAD', 'PUT', 'DELETE'];
     var cacheableMethods = ['GET', 'HEAD'];
     superagent.patchedBySuperagentCache = true;
@@ -102,7 +102,7 @@ module.exports = function(agent, cache, defaults){
      * Wraps the .end function so that .resetProps gets called--callable so that no caching logic takes place
      */
     Request.prototype._end = function(cb){
-      props = resetProps();
+      props = resetProps(superagent.defaults);
       this.execute(cb);
     }
 
@@ -112,7 +112,7 @@ module.exports = function(agent, cache, defaults){
      */
     Request.prototype.end = function(cb){
       var curProps = props;
-      props = resetProps();
+      props = resetProps(superagent.defaults);
       if(~supportedMethods.indexOf(this.method)){
         var _this = this;
         var key = keygen(this, curProps);
@@ -311,16 +311,16 @@ module.exports = function(agent, cache, defaults){
     /**
      * Reset superagent-cache's default query properties
      */
-    function resetProps(){
+    function resetProps(d){
       return {
-        doQuery: (typeof defaults.doQuery === 'boolean') ? defaults.doQuery : true,
-        cacheWhenEmpty: (typeof defaults.cacheWhenEmpty === 'boolean') ? defaults.cacheWhenEmpty : true,
-        prune: defaults.prune,
-        pruneParams: defaults.pruneParams,
-        pruneOptions: defaults.pruneOptions,
-        responseProp: defaults.responseProp,
-        expiration: defaults.expiration,
-        backgroundRefresh: defaults.backgroundRefresh
+        doQuery: (typeof d.doQuery === 'boolean') ? d.doQuery : true,
+        cacheWhenEmpty: (typeof d.cacheWhenEmpty === 'boolean') ? d.cacheWhenEmpty : true,
+        prune: d.prune,
+        pruneParams: d.pruneParams,
+        pruneOptions: d.pruneOptions,
+        responseProp: d.responseProp,
+        expiration: d.expiration,
+        backgroundRefresh: d.backgroundRefresh
       };
     }
 

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -8,11 +8,7 @@ module.exports = function(agent, cache, defaults){
 
   var superagent = (agent) ? agent : require('superagent');
 
-  if(superagent.patchedBySuperagentCache){
-    superagent.cache = (cache) ? cache : superagent.cache;
-    superagent.defaults = (defaults) ? resetProps(defaults) : superagent.defaults;
-  }
-  else if(!superagent.patchedBySuperagentCache){
+  if(!superagent.patchedBySuperagentCache){
     superagent.cache = (cache) ? cache : new require('cache-service-cache-module')();
     superagent.defaults = defaults || {};
     var Request = superagent.Request;

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -8,7 +8,11 @@ module.exports = function(agent, cache, defaults){
 
   var superagent = (agent) ? agent : require('superagent');
 
-  if(!superagent.patchedBySuperagentCache){
+  if(superagent.patchedBySuperagentCache){
+    superagent.cache = (cache) ? cache : superagent.cache;
+    defaults = (defaults) ? resetProps(defaults) : null;
+  }
+  else if(!superagent.patchedBySuperagentCache){
     superagent.cache = (cache) ? cache : new require('cache-service-cache-module')();
     defaults = defaults || {};
     var Request = superagent.Request;

--- a/test/server/superagent-cache.js
+++ b/test/server/superagent-cache.js
@@ -470,12 +470,9 @@ describe('superagentCache', function(){
   });
 
   describe('configurability tests', function () {
-    //Necessary to eliminate the superagent singleton so we can create another with a defaults object
-    delete require.cache[require.resolve('superagent')];
-    var superagent = require('superagent');
-    require('../../superagentCache')(superagent, cacheModule, {doQuery: false, expiration: 1});
 
     it('Should be able to configure global settings: doQuery', function (done) {
+      superagent.defaults = {doQuery: false, expiration: 1};
       superagent
         .get('localhost:3000/one')
         .end(function (err, response, key){
@@ -488,6 +485,7 @@ describe('superagentCache', function(){
     });
 
     it('Global settings should be locally overwritten by chainables: doQuery', function (done) {
+      superagent.defaults = {doQuery: false, expiration: 1};
       superagent
         .get('localhost:3000/one')
         .doQuery(true)
@@ -502,6 +500,7 @@ describe('superagentCache', function(){
     });
 
     it('Should be able to configure global settings: expiration', function (done) {
+      superagent.defaults = {doQuery: false, expiration: 1};
       superagent
         .get('localhost:3000/one')
         .doQuery(true)
@@ -526,6 +525,7 @@ describe('superagentCache', function(){
     });
 
     it('Global settings should be locally overwritten by chainables: expiration', function (done) {
+      superagent.defaults = {doQuery: false, expiration: 1};
       superagent
         .get('localhost:3000/one')
         .doQuery(true)


### PR DESCRIPTION
Making it so that requiring superagent-cache multiple times no longer updates the cache and defaults properties. Defaults is now accessible as a public property just as cache is.