### PR TITLE
Include additional tests for caching and redirects.

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -1,3 +1,3 @@
 #/usr/bin/env bash
 
-node_modules/.bin/mocha test/server/*.js -R spec --globals CookieAccessInfo,Cookie,CookieJar,page,assets,js,css,img$MOCHA_GLOBALS
+node_modules/.bin/mocha test/server/*.js --timeout 30000 -R spec --globals CookieAccessInfo,Cookie,CookieJar,page,assets,js,css,img$MOCHA_GLOBALS

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "cache-service-cache-module": "1.2.2"
   },
   "devDependencies": {
-    "mocha": "1.13.0",
+    "es6-promise": "^3.0.2",
     "expect": "1.6.0",
     "express": "3.4.3",
+    "mocha": "1.13.0",
     "mock-localstorage": "0.1.3"
   },
   "scripts": {


### PR DESCRIPTION
I added tests that show `superagent-cache` giving a different response from plain `superagent` for redirects. You can also see a simplified version here: https://gist.github.com/ariutta/972aba5adfb4063d1876