### PR TITLE
2.0.0 -- superagent 2 and 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ All options that can be passed to the `defaults` `require` param can be overwrit
 
 * responseProp
 * prune
-* pruneParams
-* pruneOptions
+* pruneQuery
+* pruneHeader
 * expiration
 * cacheWhenEmpty
 * doQuery
@@ -223,9 +223,9 @@ superagent
 );
 ```
 
-## .pruneParams(params)
+## .pruneQuery(params)
 
-In the event that you need certain query params to execute a query but cannot have those params as part of your cache key (useful when security or time-related params are sent), use `.pruneParams()` to remove those properties. Pass `.pruneParams()` an array containing the param keys you want omitted from the cache key.
+In the event that you need certain query params to execute a query but cannot have those params as part of your cache key (useful when security or time-related params are sent), use `.pruneQuery()` to remove those properties. Pass `.pruneQuery()` an array containing the param keys you want omitted from the cache key.
 
 #### Arguments
 
@@ -239,16 +239,16 @@ In the event that you need certain query params to execute a query but cannot ha
 superagent
   .get(uri)
   .query(query)
-  .pruneParams(['token'])
+  .pruneQuery(['token'])
   .end(function (error, response){
     // handle response
   }
 );
 ```
 
-## .pruneOptions(options)
+## .pruneHeader(options)
 
-This function works just like the `.pruneParams()` funciton except that it modifies the arguments passed to the `.set()` chainable method (headers) rather than those passed to the `.query()` chainable method.
+This function works just like the `.pruneQuery()` funciton except that it modifies the arguments passed to the `.set()` chainable method (headers) rather than those passed to the `.query()` chainable method.
 
 #### Arguments
 
@@ -262,7 +262,7 @@ This function works just like the `.pruneParams()` funciton except that it modif
 superagent
   .get(uri)
   .set(options)
-  .pruneOptions(['token'])
+  .pruneHeader(['token'])
   .end(function (error, response){
     // handle response
   }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Upgrading from an older version or seeing a bug? Please see the [Breaking Change
 
 Require and instantiate superagent-cache as follows to get the [default configuration](#what-does-the-default-configuration-give-me):
 ```javascript
-var superagent = require('superagent-cache')();
+var superagent = require('superagent');
+require('superagent-cache')(superagent);
 ```
 Now you're ready for the magic! All of your existing `GET` and `HEAD` requests will be cached with no extra bloat in your queries! Any matching `DELETE`, `POST`, `PUT`, or `PATCH` requests will automatically invalidate the associated cache key and value.
 ```javascript
@@ -91,11 +92,11 @@ By default, `superagent-cache` stores data in a bundled instance of [cacheModule
 
 # What Does the Default Configuration Give Me?
 
-You get the 'default configuration' when you don't provide any params to the `require('superagent-cache')()` command. This will return a fresh instance of `superagent` and bundle an instance of [cacheModule](https://github.com/jpodwys/cache-service-cache-module) for storing data. `cacheModule` is a slim, in-memory cache.
+You get the 'default configuration' when you only provide a superagent instance to the `require('superagent-cache')()` command. This will patch the passed instance of `superagent` and bundle an instance of [cacheModule](https://github.com/jpodwys/cache-service-cache-module) for storing data. `cacheModule` is a slim, in-memory cache.
 
 # How Do I Use a Custom Configuration?
 
-To use a custom configuraiton, take advantage of the the three optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) (`superagent`, `cache`, and `defaults`) as follows:
+To use a custom configuraiton, take advantage of the the two optional params you can hand to `superagent-cache`'s [`require` command](#user-content-requiresuperagent-cachesuperagent-cache) (`cache`, and `defaults`) as follows:
 
 ```javascript
 //Require superagent and the cache module I want
@@ -108,7 +109,7 @@ var defaults = {cacheWhenEmpty: false, expiration: 900};
 require('superagent-cache')(superagent, redisCache, defaults);
 ```
 
-This example allows you to provide your own instance of `superagent` to be patched as well as allowing you to pass in your own, pre-instantiated cache and some defaults for superagent-cache to use with all queries. Here's a list of [supported caches](#supported-caches).
+This example patches your instance of `superagent` as allowing you to pass in your own, pre-instantiated cache and some defaults for superagent-cache to use with all queries. Here's a list of [supported caches](#supported-caches).
 
 The `cache` param can be either a pre-instantiated cache module, or a [`cacheModuleConfig` object](https://github.com/jpodwys/cache-service-cache-module#cache-module-configuration-options) to be used with superagent-cache's bundled [`cacheModule`](https://github.com/jpodwys/cache-service-cache-module) instance.
 
@@ -449,12 +450,7 @@ However, you can only get it when you pass 3 params to the callback's argument l
 
 ## Various ways of requiring superagent-cache
 
-#### When no params are passed
-
-```javascript
-//...it will return a patched superagent instance and create a cache-service instance with the default configuration
-var superagent = require('superagent-cache')();
-```
+> NOTE: You must pass your own superagent instance or superagent-cache will throw an error.
 
 #### When only `superagent` is passed
 
@@ -464,23 +460,25 @@ var superagent = require('superagent');
 require('superagent-cache')(superagent)
 ```
 
-#### When only `cache` is passed
+#### When `superagent` and `cache` are passed
 
 > Example 1
 
 ```javascript
-//...it will return a patched superagent instance and consume cache as its data store
+//...it will patched the provided superagent instance and consume cache as its data store
+var superagent = require('superagent');
 var redisModule = require('cache-service-redis');
 var redisCache = new redisModule({redisEnv: 'REDISCLOUD_URL'});
-var superagent = require('superagent-cache')(null, redisCache);
+var superagent = require('superagent-cache')(superagent, redisCache);
 ```
 
 > Example 2
 
 ```javascript
-//...it will return a patched superagent instance and consume cache as its cacheModuleConfig for use with the bundled instance of cacheModule
+//...it will patched the provided superagent instance and consume cache as its cacheModuleConfig for use with the bundled instance of cacheModule
+var superagent = require('superagent');
 var cacheModuleConfig = {storage: 'session', defaultExpiration: 60};
-var superagent = require('superagent-cache')(null, cacheModuleConfig);
+var superagent = require('superagent-cache')(superagent, cacheModuleConfig);
 ```
 
 #### With `defaults`
@@ -492,6 +490,7 @@ The `defaults` object can be passed as the third param at any time. It does not 
 #### 2.0.0
 
 * Now compatible with superagent `2.x` and `3.x`
+* Because superagent-cache is now compatible with superagent 1, 2, and 3, it does not bundle an instance of superagent. As a result, you must always provide your own instance to be patched.
 * `._end` is now `._superagentCache_originalEnd` to prevent future naming colisions
 * `.pruneParams` is now `.pruneQuery` for clarity
 * `.pruneOptions` is now `.pruneHeader` for clarity

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Superagent with flexible built-in caching.
 
 > Note: superagent-cache is a global patch for superagent. If you prefer the same built-in caching as a superagent plugin, see [superagent-cache-plugin](https://github.com/jpodwys/superagent-cache-plugin).
 
-Currently tested against superagent `1.x`.
-
 Upgrading from an older version or seeing a bug? Please see the [Breaking Change History](#breaking-change-history) section.
 
 # Contents
@@ -169,26 +167,6 @@ Same as superagent except that superagent's response object will be cached.
 
 Same as superagent except that the generated cache key will be automatically invalidated when these `HTTP` verbs are used.
 
-## .then(resolve, reject)
-
-In its [`1.3.0` release](https://github.com/visionmedia/superagent/releases/tag/v1.3.0), superagent added fake promise support in the form of a `.then()` chainable that accepts two functions. Before superagent `2.x`, this function does not return a real promise. Rather, it calls `.end()` internally and then decides which function (`resolve` or `reject`) to call. (superagent-cache does not yet support superagent `2.x`.)
-
-> Should work with [`superagent-promise`](https://github.com/lightsofapollo/superagent-promise), [`superagent-bluebird-promise`](https://github.com/KyleAMathews/superagent-bluebird-promise), and [`superagent-promise-plugin`](https://github.com/jomaxx/superagent-promise-plugin) (perhaps others as well).
-
-I've overwritten superagent's `.then()` so that the provided `resolve` function accepts the generate cache key as follows:
-
-```javascript
-superagent
-  .get(uri)
-  .then(function (response, key){
-    // handle response--key is available if desired
-  }, function (err){
-    // handle the error
-  }
-);
-
-```
-
 ## .end(callback ([err,] response [, key]))
 
 Same as superagent except it optionally exposes the key superagent-cache generates as the third param in the callback's argument list. See the [usage example](#end-callback-argument-list-options) for a more detailed explanation.
@@ -345,7 +323,7 @@ Tell the underlying `cache` provided in the `require` command to enable backgrou
 
 * value: boolean || function || undefined, default: true
 
-## ._end(callback (err, response))
+## ._superagenCache_originalEnd(callback (err, response))
 
 This is a convenience method that allows you to skip all caching logic and use superagent as normal.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Superagent with flexible built-in caching.
 
+Now compatible with superagent `2.x` and `3.x`
+
 > Note: superagent-cache is a global patch for superagent. If you prefer the same built-in caching as a superagent plugin, see [superagent-cache-plugin](https://github.com/jpodwys/superagent-cache-plugin).
 
 Upgrading from an older version or seeing a bug? Please see the [Breaking Change History](#breaking-change-history) section.
@@ -323,7 +325,7 @@ Tell the underlying `cache` provided in the `require` command to enable backgrou
 
 * value: boolean || function || undefined, default: true
 
-## ._superagenCache_originalEnd(callback (err, response))
+## ._superagentCache_originalEnd(callback (err, response))
 
 This is a convenience method that allows you to skip all caching logic and use superagent as normal.
 
@@ -486,6 +488,14 @@ var superagent = require('superagent-cache')(null, cacheModuleConfig);
 The `defaults` object can be passed as the third param at any time. It does not affect the `superagent` or `cache` params. You can see a brief demo [here](#how-do-i-use-a-custom-configuration) and a list of all the options you can pass in the `defaults` object [here](#available-configuration-options).
 
 # Breaking Change History
+
+#### 2.0.0
+
+* Now compatible with superagent `2.x` and `3.x`
+* `._end` is now `._superagentCache_originalEnd` to prevent future naming colisions
+* `.pruneParams` is now `.pruneQuery` for clarity
+* `.pruneOptions` is now `.pruneHeader` for clarity
+* The `resolve` function passed to `.then` no longer exposes the generated cache key like it did when using superagent `^1.3.0` with superagent-cache `^1.5.0` (but using `.end` still does)
 
 #### 1.3.5
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Superagent with flexible built-in caching.
 
-Now compatible with superagent `2.x` and `3.x`
+Now compatible with superagent `2.x` and `3.x`.
 
 > Note: superagent-cache is a global patch for superagent. If you prefer the same built-in caching as a superagent plugin, see [superagent-cache-plugin](https://github.com/jpodwys/superagent-cache-plugin).
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Superagent with flexible built-in caching.",
   "main": "superagentCache.js",
   "dependencies": {
-    "superagent": "3.x",
     "cache-service-cache-module": "1.x"
   },
   "devDependencies": {
+    "superagent": "3.x",
     "es6-promise": "3.0.2",
     "expect": "1.6.0",
     "express": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "superagent-cache",
-  "version": "1.7.2",
+  "version": "2.0.0",
   "description": "Superagent with flexible built-in caching.",
   "main": "superagentCache.js",
   "dependencies": {
-    "superagent": "1.7.2",
+    "superagent": "3.x",
     "cache-service-cache-module": "1.x"
   },
   "devDependencies": {

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -32,19 +32,19 @@ module.exports = function(agent, cache, defaults){
 
     /**
      * Remove the given params from the query object after executing an http query and before generating a cache key
-     * @param {array of strings} pruneParams
+     * @param {array of strings} pruneQuery
      */
-    Request.prototype.pruneParams = function(pruneParams){
-      props.pruneParams = pruneParams;
+    Request.prototype.pruneQuery = function(pruneQuery){
+      props.pruneQuery = pruneQuery;
       return this;
     }
 
     /**
      * Remove the given options from the headers object after executing an http query and before generating a cache key
-     * @param {boolean} pruneOptions
+     * @param {boolean} pruneHeader
      */
-    Request.prototype.pruneOptions = function(pruneOptions){
-      props.pruneOptions = pruneOptions;
+    Request.prototype.pruneHeader = function(pruneHeader){
+      props.pruneHeader = pruneHeader;
       return this;
     }
 
@@ -76,7 +76,7 @@ module.exports = function(agent, cache, defaults){
     }
 
     /**
-     * Whether to cache superagent's http response object when it "empty"--especially useful with .prune and .pruneParams
+     * Whether to cache superagent's http response object when it "empty"--especially useful with .prune and .pruneQuery
      * @param {boolean} cacheWhenEmpty
      */
     Request.prototype.cacheWhenEmpty = function(cacheWhenEmpty){

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -121,7 +121,7 @@ module.exports = function(agent, cache, defaults){
     /**
      * Wraps the .end function so that .resetProps gets called--callable so that no caching logic takes place
      */
-    Request.prototype._superagenCache_originalEnd = function(cb){
+    Request.prototype._superagentCache_originalEnd = function(cb){
       props = utils.resetProps(superagent.defaults);
       this._superagentCache_execute(cb);
     }
@@ -152,7 +152,7 @@ module.exports = function(agent, cache, defaults){
                     return superagent.pendingRequests[key].push(cb);
                   }
                 }
-                _this._superagenCache_originalEnd(function (err, response){
+                _this._superagentCache_originalEnd(function (err, response){
                   if(err){
                     utils.handlePendingRequests(curProps, superagent, key, err, response);
                     return utils.callbackExecutor(cb, err, response, key);
@@ -192,7 +192,7 @@ module.exports = function(agent, cache, defaults){
           });
         }
         else{
-          this._superagenCache_originalEnd(function (err, response){
+          this._superagentCache_originalEnd(function (err, response){
             if(err){
               return utils.callbackExecutor(cb, err, response, key);
             }
@@ -207,7 +207,7 @@ module.exports = function(agent, cache, defaults){
         }
       }
       else{
-        this._superagenCache_originalEnd(function (err, response){
+        this._superagentCache_originalEnd(function (err, response){
           return utils.callbackExecutor(cb, err, response, undefined);
         });
       }

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -3,13 +3,13 @@ var utils = require('./utils');
 /**
  * superagentCache constructor
  * @constructor
- * @param {superagent} agent (optional)
+ * @param {superagent} superagent
  * @param {cache module} cache (optional)
  * @param {object} defaults (optional)
  */
-module.exports = function(agent, cache, defaults){
+module.exports = function(superagent, cache, defaults){
 
-  var superagent = (agent) ? agent : require('superagent');
+  if(!superagent) throw 'superagent-cache requires a superagent instance.';
 
   if(!superagent.patchedBySuperagentCache){
     superagent.cache = (cache && cache.get) ? cache : new (require('cache-service-cache-module'))(cache);
@@ -212,10 +212,6 @@ module.exports = function(agent, cache, defaults){
         });
       }
     }
-  }
-
-  if(!agent){
-    return superagent;
   }
 
 }

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -114,29 +114,16 @@ module.exports = function(agent, cache, defaults){
     }
 
     /**
-     * Overwrites superagent's fake promise support and adds the generated cache key
-     * Only applies if Request.prototype.promise is not set
-     * Fixes this isse: https://github.com/jpodwys/superagent-cache/issues/38
+     * An alias for the .end function
      */
-    if(!Request.prototype.promise){
-      Request.prototype.then = function(fulfill, reject){
-        return this.end(function (err, response, key) {
-          err ? reject(err) : fulfill(response, key);
-        });
-      }
-    }
-
-    /**
-     * An alias for the .end function because I use ._end and .end for other things
-     */
-    Request.prototype.execute = Request.prototype.end;
+    Request.prototype._superagentCache_execute = Request.prototype.end;
 
     /**
      * Wraps the .end function so that .resetProps gets called--callable so that no caching logic takes place
      */
-    Request.prototype._end = function(cb){
+    Request.prototype._superagenCache_originalEnd = function(cb){
       props = utils.resetProps(superagent.defaults);
-      this.execute(cb);
+      this._superagentCache_execute(cb);
     }
 
     /**
@@ -165,7 +152,7 @@ module.exports = function(agent, cache, defaults){
                     return superagent.pendingRequests[key].push(cb);
                   }
                 }
-                _this._end(function (err, response){
+                _this._superagenCache_originalEnd(function (err, response){
                   if(err){
                     utils.handlePendingRequests(curProps, superagent, key, err, response);
                     return utils.callbackExecutor(cb, err, response, key);
@@ -205,7 +192,7 @@ module.exports = function(agent, cache, defaults){
           });
         }
         else{
-          this._end(function (err, response){
+          this._superagenCache_originalEnd(function (err, response){
             if(err){
               return utils.callbackExecutor(cb, err, response, key);
             }
@@ -220,7 +207,7 @@ module.exports = function(agent, cache, defaults){
         }
       }
       else{
-        this._end(function (err, response){
+        this._superagenCache_originalEnd(function (err, response){
           return utils.callbackExecutor(cb, err, response, undefined);
         });
       }

--- a/test/server/api.js
+++ b/test/server/api.js
@@ -40,11 +40,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){
@@ -176,65 +176,65 @@ describe('superagentCache', function(){
       );
     });
 
-    it('.get() .query(object) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(object) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
-        .query({pruneParams: true, otherParams: false})
-        .pruneParams(['pruneParams'])
+        .query({pruneQuery: true, otherParams: false})
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       );
     });
 
-    it('.get() .query(string&string) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(string&string) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
-        .query('pruneParams=true&otherParams=false')
-        .pruneParams(['pruneParams'])
+        .query('pruneQuery=true&otherParams=false')
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       );
     });
 
-    it('.get() .query(string) .query(string) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(string) .query(string) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
-        .query('pruneParams=true')
+        .query('pruneQuery=true')
         .query('otherParams=false')
-        .pruneParams(['pruneParams'])
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       )
     });
 
-    it('.get() .pruneOptions() .end() should query with all options but create a key without the indicated options', function (done) {
+    it('.get() .pruneHeader() .end() should query with all options but create a key without the indicated options', function (done) {
       superagent
         .get('localhost:3000/options')
-        .set({pruneOptions: true, otherOptions: false})
-        .pruneOptions(['pruneOptions'])
+        .set({pruneHeader: true, otherOptions: false})
+        .pruneHeader(['pruneHeader'])
         .end(function (err, response, key){
           //console.log(key);
-          expect(response.body.pruneOptions).toBe('true');
+          expect(response.body.pruneHeader).toBe('true');
           expect(response.body.otherOptions).toBe('false');
           //Before superagent 1.7.0, superagent converts headers to lower case. To be backwards compatible,
           //I check for lower as well as the upper case versions of the headers sent above
-          expect(key.indexOf('pruneoptions')).toBe(-1);
-          expect(key.indexOf('pruneOptions')).toBe(-1);
+          expect(key.indexOf('pruneHeader')).toBe(-1);
+          expect(key.indexOf('pruneHeader')).toBe(-1);
           var lowerOtherOptions = key.indexOf('otheroptions');
           var upperOtherOptions = key.indexOf('otherOptions');
           var otherOptionsIsPresent = (lowerOtherOptions > -1 || upperOtherOptions > -1);

--- a/test/server/background-refresh.js
+++ b/test/server/background-refresh.js
@@ -40,11 +40,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){
@@ -125,12 +125,12 @@ describe('superagentCache', function(){
     it('.get() .query(string&string) .end() background refresh should not work if the chainable is not used', function (done) {
       superagent
         .get('localhost:3000/params')
-        .query('pruneParams=true&otherParams=false')
-        .pruneParams(['pruneParams'])
+        .query('pruneQuery=true&otherParams=false')
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           setTimeout(function(){
             superagent.cache.get(key, function (err, response){
@@ -145,19 +145,19 @@ describe('superagentCache', function(){
     it('.get() .query(string&string) .backgroundRefresh(true) .end() background refresh should refresh a key shortly before expiration', function (done) {
       superagent
         .get('localhost:3000/params')
-        .query('pruneParams=true&otherParams=false')
-        .pruneParams(['pruneParams'])
+        .query('pruneQuery=true&otherParams=false')
+        .pruneQuery(['pruneQuery'])
         .backgroundRefresh(true)
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           setTimeout(function(){
             superagent.cache.get(key, function (err, response){
-              expect(response.body.pruneParams).toBe('true');
+              expect(response.body.pruneQuery).toBe('true');
               expect(response.body.otherParams).toBe('false');
-              expect(key.indexOf('pruneParams')).toBe(-1);
+              expect(key.indexOf('pruneQuery')).toBe(-1);
               expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
               done();
             });

--- a/test/server/caching.js
+++ b/test/server/caching.js
@@ -130,10 +130,10 @@ describe('superagentCache', function(){
       );
     });
 
-    it('.get() ._end() should bypass all caching logic', function (done) {
+    it('.get() ._superagenCache_originalEnd() should bypass all caching logic', function (done) {
       superagent
         .get('localhost:3000/one')
-        ._end(function (err, response, key){
+        ._superagenCache_originalEnd(function (err, response, key){
           expect(typeof key).toBe('undefined');
           expect(response.body.key).toBe('one');
           checkBrowserStorage(key, false);

--- a/test/server/caching.js
+++ b/test/server/caching.js
@@ -55,11 +55,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){

--- a/test/server/configurability.js
+++ b/test/server/configurability.js
@@ -41,11 +41,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){

--- a/test/server/force-update.js
+++ b/test/server/force-update.js
@@ -37,11 +37,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){

--- a/test/server/prevent-duplicate-calls.js
+++ b/test/server/prevent-duplicate-calls.js
@@ -33,11 +33,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/redirect', function(req, res){

--- a/utils.js
+++ b/utils.js
@@ -10,9 +10,9 @@ module.exports = {
     var cleanOptions = null;
     var params = this.getQueryParams(req);
     var options = this.getHeaderOptions(req);
-    if(cProps.pruneParams || cProps.pruneOptions){
-      cleanParams = (cProps.pruneParams) ? this.pruneObj(this.cloneObject(params), cProps.pruneParams) : params;
-      cleanOptions = (cProps.pruneOptions) ? this.pruneObj(this.cloneObject(options), cProps.pruneOptions, true) : options;
+    if(cProps.pruneQuery || cProps.pruneHeader){
+      cleanParams = (cProps.pruneQuery) ? this.pruneObj(this.cloneObject(params), cProps.pruneQuery) : params;
+      cleanOptions = (cProps.pruneHeader) ? this.pruneObj(this.cloneObject(options), cProps.pruneHeader, true) : options;
     }
     return JSON.stringify({
       nameSpace: agent.cache.nameSpace,
@@ -178,8 +178,8 @@ module.exports = {
       doQuery: (typeof d.doQuery === 'boolean') ? d.doQuery : true,
       cacheWhenEmpty: (typeof d.cacheWhenEmpty === 'boolean') ? d.cacheWhenEmpty : true,
       prune: d.prune,
-      pruneParams: d.pruneParams,
-      pruneOptions: d.pruneOptions,
+      pruneQuery: d.pruneQuery,
+      pruneHeader: d.pruneHeader,
       responseProp: d.responseProp,
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,
@@ -199,8 +199,8 @@ module.exports = {
       var method = key.method.toLowerCase();
       var request = agent[method](key.uri)
         .doQuery(curProps.doQuery)
-        .pruneParams(curProps.pruneParams)
-        .pruneOptions(curProps.pruneOptions)
+        .pruneQuery(curProps.pruneQuery)
+        .pruneHeader(curProps.pruneHeader)
         .prune(curProps.prune)
         .responseProp(curProps.responseProp)
         .expiration(curProps.expiration)


### PR DESCRIPTION
#### Changes

* `._end` -> `._superagentCache_originalEnd` to prevent naming colisions
* `.pruneParams` -> `.pruneQuery` for clarity
* `.pruneOptions` -> `.pruneHeader` for clarity
* No longer wrapping `.then` since superagent uses real promises since `2.x`. As a result, the `resolve` function passed to `.then` no longer exposes the generated cache key like it did when using superagent `^1.3.0` with superagent-cache `^1.5.0` (but using `.end` still does)