### PR TITLE
Consume cache-service-cache-module 2.x.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,508 @@
+{
+  "name": "superagent-cache",
+  "version": "3.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
+      "integrity": "sha1-qtM+wU49wsp06OfUUfm6BTrU96A=",
+      "dev": true
+    },
+    "cache-service-cache-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cache-service-cache-module/-/cache-service-cache-module-2.0.0.tgz",
+      "integrity": "sha512-sSalqq029K0JbqgkWXKetL06wqQZuHtEJxHoDv1AfyhvDTT17Zx9pKoeffmkPdvl2y69PWVa5AeK68QVX+zSRA=="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+      "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+      "dev": true,
+      "requires": {
+        "keypress": "0.1.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "connect": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.10.1.tgz",
+      "integrity": "sha1-28aTklJ7NpNSKdwp43IkmuusZEg=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "bytes": "0.2.0",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "3.1.0",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "multiparty": "2.2.0",
+        "negotiator": "0.2.8",
+        "pause": "0.0.1",
+        "qs": "0.6.5",
+        "raw-body": "0.0.3",
+        "send": "0.1.4",
+        "uid2": "0.0.2"
+      }
+    },
+    "cookie": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
+      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+      "dev": true
+    },
+    "expect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-1.6.0.tgz",
+      "integrity": "sha1-j90OgP8B3AU3n1agswzi8UB//4w=",
+      "dev": true
+    },
+    "express": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.4.3.tgz",
+      "integrity": "sha1-0NI31gzZx0G1DaiDeVJ+Kh2ARic=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "commander": "1.3.2",
+        "connect": "2.10.1",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "3.1.0",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "mkdirp": "0.3.5",
+        "range-parser": "0.0.4",
+        "send": "0.1.4"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "2.0.3",
+        "inherits": "2.0.3",
+        "minimatch": "0.2.14"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "methods": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "mocha": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.13.0.tgz",
+      "integrity": "sha1-jY+k4xC5TMbv6z7SauypbeqTMHw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "debug": "3.1.0",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.0",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        }
+      }
+    },
+    "mock-localstorage": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mock-localstorage/-/mock-localstorage-0.1.3.tgz",
+      "integrity": "sha1-oulMLDq7u59jRYvHwFa/pOcRSMU=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multiparty": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+      "integrity": "sha1-pWfCrwAK0i3I8qZT2Rl4rh9TFvQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "stream-counter": "0.2.0"
+      }
+    },
+    "negotiator": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.8.tgz",
+      "integrity": "sha1-rf0gejh1xNNwlXKcLnwoPFui7nI=",
+      "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "qs": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+      "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8=",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.3.tgz",
+      "integrity": "sha1-DLPrIs7RymB9Mt2P2Upus4Pz64o=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+      "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "fresh": "0.2.0",
+        "mime": "1.2.11",
+        "range-parser": "0.0.4"
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "stream-counter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        }
+      }
+    },
+    "uid2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz",
+      "integrity": "sha1-EH+xVcgsETZiB5ftTIjPKwj2qrg=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "superagent-cache",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Superagent with flexible built-in caching.",
   "main": "superagentCache.js",
   "dependencies": {
-    "cache-service-cache-module": "1.x"
+    "cache-service-cache-module": "2.x"
   },
   "devDependencies": {
     "superagent": "3.x",

--- a/test/server/caching.js
+++ b/test/server/caching.js
@@ -130,10 +130,10 @@ describe('superagentCache', function(){
       );
     });
 
-    it('.get() ._superagenCache_originalEnd() should bypass all caching logic', function (done) {
+    it('.get() ._superagentCache_originalEnd() should bypass all caching logic', function (done) {
       superagent
         .get('localhost:3000/one')
-        ._superagenCache_originalEnd(function (err, response, key){
+        ._superagentCache_originalEnd(function (err, response, key){
           expect(typeof key).toBe('undefined');
           expect(response.body.key).toBe('one');
           checkBrowserStorage(key, false);


### PR DESCRIPTION
`cache-service-cache-module#2.0.0` contains [a breaking change](https://github.com/jpodwys/cache-service-cache-module/releases/tag/2.0.0). This major release consumes it.