### PR TITLE
Updated Query Param Parsers to Handle Repeated Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-cache",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Superagent with flexible built-in caching.",
   "main": "superagentCache.js",
   "dependencies": {

--- a/test/server/utils.js
+++ b/test/server/utils.js
@@ -6,10 +6,11 @@ describe('superagentCache', function() {
   describe('utility tests', function() {
 
     it('addKvArrayToObj should add parsed kvArrays to an object', function() {
-      var test = {};
+      var test = {"param1[]": 'existing', existing: 'should not change'};
       var kvArray = ['param1[]=foo', 'param2=bar', 'param1[]=baz', 'param3=hello', 'param3=world'];
       expect(utils.addKvArrayToObj(test, kvArray)).toEqual({
-        "param1[]": ['foo', 'baz'],
+        existing: 'should not change',
+        "param1[]": ['existing', 'foo', 'baz'],
         param2: 'bar',
         param3: ['hello', 'world']
       })

--- a/test/server/utils.js
+++ b/test/server/utils.js
@@ -1,0 +1,28 @@
+var utils = require('../../utils');
+var expect = require('expect');
+
+describe('superagentCache', function() {
+
+    describe('utility tests', function() {
+                
+        it('arrayToObject should parse query params', function() {
+            var test = ['param1[]=foo', 'param1[]=bar', 'param2=baz&param1[]=maybe', 'param3=true', 'param4=hello&param4=world']
+            expect(utils.arrayToObj(test)).toEqual({
+                "param1[]": ['foo', 'bar', 'maybe'],
+                param2: 'baz',
+                param3: 'true',
+                param4: ['hello', 'world']
+            })
+        })
+
+        it('stringToObject should parse query params', function() {
+            var test = 'http://example.org/params?param1[]=foo&param1[]=bar&param2=baz&param3=hello&param1[]=world'
+            expect(utils.stringToObj(test)).toEqual({
+                "param1[]": ['foo', 'bar', 'world'],
+                param2: 'baz',
+                param3: 'hello'
+            });
+        });
+
+    })
+})

--- a/test/server/utils.js
+++ b/test/server/utils.js
@@ -3,26 +3,36 @@ var expect = require('expect');
 
 describe('superagentCache', function() {
 
-    describe('utility tests', function() {
-                
-        it('arrayToObject should parse query params', function() {
-            var test = ['param1[]=foo', 'param1[]=bar', 'param2=baz&param1[]=maybe', 'param3=true', 'param4=hello&param4=world']
-            expect(utils.arrayToObj(test)).toEqual({
-                "param1[]": ['foo', 'bar', 'maybe'],
-                param2: 'baz',
-                param3: 'true',
-                param4: ['hello', 'world']
-            })
-        })
+  describe('utility tests', function() {
 
-        it('stringToObject should parse query params', function() {
-            var test = 'http://example.org/params?param1[]=foo&param1[]=bar&param2=baz&param3=hello&param1[]=world'
-            expect(utils.stringToObj(test)).toEqual({
-                "param1[]": ['foo', 'bar', 'world'],
-                param2: 'baz',
-                param3: 'hello'
-            });
-        });
+    it('addKvArrayToObj should add parsed kvArrays to an object', function() {
+      var test = {};
+      var kvArray = ['param1[]=foo', 'param2=bar', 'param1[]=baz', 'param3=hello', 'param3=world'];
+      expect(utils.addKvArrayToObj(test, kvArray)).toEqual({
+        "param1[]": ['foo', 'baz'],
+        param2: 'bar',
+        param3: ['hello', 'world']
+      })
+    });
+        
+    it('arrayToObject should parse query params', function() {
+      var test = ['param1[]=foo', 'param1[]=bar', 'param2=baz&param1[]=maybe', 'param3=true', 'param4=hello&param4=world']
+      expect(utils.arrayToObj(test)).toEqual({
+        "param1[]": ['foo', 'bar', 'maybe'],
+        param2: 'baz',
+        param3: 'true',
+        param4: ['hello', 'world']
+      })
+    });
 
-    })
+    it('stringToObject should parse query params', function() {
+      var test = 'http://example.org/params?param1[]=foo&param1[]=bar&param2=baz&param3=hello&param1[]=world'
+      expect(utils.stringToObj(test)).toEqual({
+        "param1[]": ['foo', 'bar', 'world'],
+        param2: 'baz',
+        param3: 'hello'
+      });
+    });
+
+  })
 })

--- a/utils.js
+++ b/utils.js
@@ -73,7 +73,13 @@ module.exports = {
         var kvArray = str.split('&');
         for(var j = 0; j < kvArray.length; j++){
           var kvString = kvArray[j].split('=');
-          obj[kvString[0]] = kvString[1];
+          if (Array.isArray(obj[kvString[0]])) {
+            obj[kvString[0]].push(kvString[1])
+          } else if (obj[kvString[0]]) {
+            obj[kvString[0]] = [obj[kvString[0]], kvString[1]];
+          } else {
+            obj[kvString[0]] = kvString[1];
+          }
         }
       }
       return obj;
@@ -95,7 +101,13 @@ module.exports = {
       var kvArray = str.split('&');
       for(var i = 0; i < kvArray.length; i++){
         var kvString = kvArray[i].split('=');
-        obj[kvString[0]] = kvString[1];
+        if (Array.isArray(obj[kvString[0]])) {
+          obj[kvString[0]].push(kvString[1])
+        } else if (obj[kvString[0]]) {
+          obj[kvString[0]] = [obj[kvString[0]], kvString[1]];
+        } else {
+          obj[kvString[0]] = kvString[1];
+        }
       }
       return obj;
     }

--- a/utils.js
+++ b/utils.js
@@ -62,6 +62,25 @@ module.exports = {
   },
 
   /**
+   * Add an array of key-value pairs to an object
+   * @param {object} obj
+   * @param {array} arr
+   */
+  addKvArrayToObj: function(obj, arr){
+    for(var i = 0; i < arr.length; i++){
+      var kvString = arr[i].split(`=`);
+      if (Array.isArray(obj[kvString[0]])) {
+        obj[kvString[0]].push(kvString[1])
+      } else if (obj[kvString[0]]) {
+        obj[kvString[0]] = [obj[kvString[0]], kvString[1]];
+      } else {
+        obj[kvString[0]] = kvString[1];
+      }
+    }
+    return obj;
+  },
+
+  /**
    * Convert an array to an object
    * @param {array} arr
    */
@@ -71,16 +90,7 @@ module.exports = {
       for(var i = 0; i < arr.length; i++){
         var str = arr[i];
         var kvArray = str.split('&');
-        for(var j = 0; j < kvArray.length; j++){
-          var kvString = kvArray[j].split('=');
-          if (Array.isArray(obj[kvString[0]])) {
-            obj[kvString[0]].push(kvString[1])
-          } else if (obj[kvString[0]]) {
-            obj[kvString[0]] = [obj[kvString[0]], kvString[1]];
-          } else {
-            obj[kvString[0]] = kvString[1];
-          }
-        }
+        obj = this.addKvArrayToObj(obj, kvArray);
       }
       return obj;
     }
@@ -93,23 +103,12 @@ module.exports = {
    */
   stringToObj: function(str){
     if(str){
-      var obj = {};
       if(~str.indexOf('?')){
         var strs = str.split('?');
         str = strs[1];
       }
       var kvArray = str.split('&');
-      for(var i = 0; i < kvArray.length; i++){
-        var kvString = kvArray[i].split('=');
-        if (Array.isArray(obj[kvString[0]])) {
-          obj[kvString[0]].push(kvString[1])
-        } else if (obj[kvString[0]]) {
-          obj[kvString[0]] = [obj[kvString[0]], kvString[1]];
-        } else {
-          obj[kvString[0]] = kvString[1];
-        }
-      }
-      return obj;
+      return this.addKvArrayToObj({}, kvArray);
     }
     return null;
   },

--- a/utils.js
+++ b/utils.js
@@ -62,7 +62,7 @@ module.exports = {
   },
 
   /**
-   * Add an array of key-value pairs to an object
+   * Add an array of key-value pairs to an object (mutation by reference)
    * @param {object} obj
    * @param {array} arr
    */


### PR DESCRIPTION
There didn't seem to be a way to reliably trigger specific paths in `getHeaderOptions`, and the most recent code for superagent mentions that `Request.qsRaw` is deprecated, so behavioral testing didn't seem appropriate.

Instead, I added a new test file to verify functionality at the unit level.

(I also continued to target ES5 for the code itself)